### PR TITLE
Optimize index manager

### DIFF
--- a/core/blockchain/accept.go
+++ b/core/blockchain/accept.go
@@ -152,7 +152,7 @@ func (b *BlockChain) maybeAcceptBlock(block *types.SerializedBlock, flags Behavi
 	// also handles validation of the transaction scripts.
 	_, err = b.connectDagChain(ib, block, newOrders, oldOrders)
 	if err != nil {
-		log.Warn(fmt.Sprintf("%s", err))
+		panic(err)
 	}
 
 	err = b.updateBestState(ib, block, newOrders)
@@ -215,7 +215,7 @@ func (b *BlockChain) FastAcceptBlock(block *types.SerializedBlock, flags Behavio
 
 	_, err = b.connectDagChain(ib, block, newOrders, oldOrders)
 	if err != nil {
-		log.Warn(fmt.Sprintf("%s", err))
+		panic(err)
 	}
 
 	return b.updateBestState(ib, block, newOrders)

--- a/core/blockchain/blockchain.go
+++ b/core/blockchain/blockchain.go
@@ -997,7 +997,7 @@ func (b *BlockChain) connectBlock(node meerdag.IBlock, block *types.SerializedBl
 			// optional indexes with the block being connected so they can
 			// update themselves accordingly.
 			if b.indexManager != nil {
-				err := b.indexManager.ConnectBlock(dbTx, block, stxos)
+				err := b.indexManager.ConnectBlock(dbTx, block, stxos, node)
 				if err != nil {
 					return err
 				}
@@ -1020,7 +1020,7 @@ func (b *BlockChain) connectBlock(node meerdag.IBlock, block *types.SerializedBl
 		// Atomically insert info into the database.
 		err := b.db.Update(func(dbTx database.Tx) error {
 			if b.indexManager != nil {
-				err := b.indexManager.ConnectBlock(dbTx, block, stxos)
+				err := b.indexManager.ConnectBlock(dbTx, block, stxos, node)
 				if err != nil {
 					return err
 				}
@@ -1209,8 +1209,7 @@ func (b *BlockChain) reorganizeChain(ib meerdag.IBlock, detachNodes *list.List, 
 		err = b.connectBlock(nodeBlock, block, view, stxos)
 		if err != nil {
 			b.bd.InvalidBlock(nodeBlock)
-			log.Info(fmt.Sprintf("%s", err))
-			continue
+			return err
 		}
 		if !nodeBlock.GetStatus().KnownInvalid() {
 			b.bd.ValidBlock(nodeBlock)

--- a/core/blockchain/blockindex.go
+++ b/core/blockchain/blockindex.go
@@ -3,9 +3,9 @@ package blockchain
 
 import (
 	"github.com/Qitmeer/qng-core/common/hash"
-	"github.com/Qitmeer/qng-core/meerdag"
 	"github.com/Qitmeer/qng-core/core/types"
 	"github.com/Qitmeer/qng-core/database"
+	"github.com/Qitmeer/qng-core/meerdag"
 )
 
 // IndexManager provides a generic interface that the is called when blocks are
@@ -21,7 +21,7 @@ type IndexManager interface {
 
 	// ConnectBlock is invoked when a new block has been connected to the
 	// main chain.
-	ConnectBlock(tx database.Tx, block *types.SerializedBlock, stxos []SpentTxOut) error
+	ConnectBlock(tx database.Tx, block *types.SerializedBlock, stxos []SpentTxOut, ib meerdag.IBlock) error
 
 	// DisconnectBlock is invoked when a block has been disconnected from
 	// the main chain.

--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.14
 
 require (
 	github.com/Qitmeer/meerevm v0.0.0-20220217030149-dda74170532e
-	github.com/Qitmeer/qng-core v1.2.12
+	github.com/Qitmeer/qng-core v1.2.13
 	github.com/davecgh/go-spew v1.1.1
 	github.com/davidlazar/go-crypto v0.0.0-20190912175916-7055855a373f // indirect
 	github.com/deckarep/golang-set v1.7.1

--- a/go.sum
+++ b/go.sum
@@ -66,8 +66,8 @@ github.com/Qitmeer/go-ethereum v1.10.9-q.5 h1:zLwIePKqwmWbbevuMDgAplMj7zpEMkrgNz
 github.com/Qitmeer/go-ethereum v1.10.9-q.5/go.mod h1:8bALkv9mq8Bvsw8TEUaxO2TtxAGRxoXebspLZ+CSJ9U=
 github.com/Qitmeer/meerevm v0.0.0-20220217030149-dda74170532e h1:TGiHI3NO+IpAWasQSv5hHon8O4g2R7dFkw3ecfXsNEk=
 github.com/Qitmeer/meerevm v0.0.0-20220217030149-dda74170532e/go.mod h1:0SjFNfbI7l2I1CLpRa5z3Oy0FDYyk0jz0EMf7I2XecQ=
-github.com/Qitmeer/qng-core v1.2.12 h1:p2xxL1cbYjpRO/hKmS5wnFaJiWsbcyZVD1LC0VPZtLk=
-github.com/Qitmeer/qng-core v1.2.12/go.mod h1:VeXRmyRHYSezmAJ7KzZgOt+mC5B/E0H6cE9m7IFWVKg=
+github.com/Qitmeer/qng-core v1.2.13 h1:TLrU+6tCzkUHiKGUX38xfUIV+MdpCJgSLbQYJAp2drI=
+github.com/Qitmeer/qng-core v1.2.13/go.mod h1:VeXRmyRHYSezmAJ7KzZgOt+mC5B/E0H6cE9m7IFWVKg=
 github.com/Shopify/sarama v1.29.1/go.mod h1:mdtqvCSg8JOxk8PmpTNGyo6wzd4BMm4QXSfDnTXmgkE=
 github.com/Shopify/toxiproxy v2.1.4+incompatible/go.mod h1:OXgGpZ6Cli1/URJOF1DMxUHB2q5Ap20/P/eIdh4G0pI=
 github.com/StackExchange/wmi v0.0.0-20180116203802-5d049714c4a6 h1:fLjPD/aNc3UIOA6tDi6QXUemppXK3P9BI7mr2hd6gx8=

--- a/services/index/addrindex.go
+++ b/services/index/addrindex.go
@@ -13,12 +13,12 @@ import (
 
 	"github.com/Qitmeer/qng-core/common/hash"
 	"github.com/Qitmeer/qng-core/core/address"
-	"github.com/Qitmeer/qng/core/blockchain"
 	"github.com/Qitmeer/qng-core/core/types"
 	"github.com/Qitmeer/qng-core/crypto/ecc"
 	"github.com/Qitmeer/qng-core/database"
 	"github.com/Qitmeer/qng-core/engine/txscript"
 	"github.com/Qitmeer/qng-core/params"
+	"github.com/Qitmeer/qng/core/blockchain"
 )
 
 const (

--- a/services/index/addrindex.go
+++ b/services/index/addrindex.go
@@ -9,6 +9,7 @@ package index
 import (
 	"errors"
 	"fmt"
+	"github.com/Qitmeer/qng-core/meerdag"
 	"sync"
 
 	"github.com/Qitmeer/qng-core/common/hash"
@@ -745,8 +746,10 @@ func (idx *AddrIndex) indexBlock(data writeIndexData, block *types.SerializedBlo
 // the transactions in the block involve.
 //
 // This is part of the Indexer interface.
-func (idx *AddrIndex) ConnectBlock(dbTx database.Tx, block *types.SerializedBlock, stxos []blockchain.SpentTxOut) error {
-
+func (idx *AddrIndex) ConnectBlock(dbTx database.Tx, block *types.SerializedBlock, stxos []blockchain.SpentTxOut, ib meerdag.IBlock) error {
+	if ib.GetStatus().KnownInvalid() {
+		return nil
+	}
 	// The offset and length of the transactions within the serialized
 	// block.
 	txLocs, err := block.TxLoc()

--- a/services/index/addrindex.go
+++ b/services/index/addrindex.go
@@ -755,7 +755,7 @@ func (idx *AddrIndex) ConnectBlock(dbTx database.Tx, block *types.SerializedBloc
 	}
 	// Get the internal block ID associated with the block.
 	blockHash := block.Hash()
-	blockID, err := dbFetchBlockIDByHash(dbTx, blockHash)
+	blockID, err := dbFetchOrderByHash(dbTx, blockHash)
 	if err != nil {
 		return err
 	}

--- a/services/index/addrindex.go
+++ b/services/index/addrindex.go
@@ -634,7 +634,7 @@ func (idx *AddrIndex) NeedsInputs() bool {
 // initialize for this index.
 //
 // This is part of the Indexer interface.
-func (idx *AddrIndex) Init() error {
+func (idx *AddrIndex) Init(chain *blockchain.BlockChain) error {
 	// Nothing to do.
 	return nil
 }

--- a/services/index/common.go
+++ b/services/index/common.go
@@ -48,7 +48,7 @@ type Indexer interface {
 	// Init is invoked when the index manager is first initializing the
 	// index.  This differs from the Create method in that it is called on
 	// every load, including the case the index was just created.
-	Init() error
+	Init(chain *blockchain.BlockChain) error
 
 	// ConnectBlock is invoked when the index manager is notified that a new
 	// block has been connected to the main chain.

--- a/services/index/common.go
+++ b/services/index/common.go
@@ -12,6 +12,7 @@ import (
 	"errors"
 	"github.com/Qitmeer/qng-core/core/types"
 	"github.com/Qitmeer/qng-core/database"
+	"github.com/Qitmeer/qng-core/meerdag"
 	"github.com/Qitmeer/qng/core/blockchain"
 )
 
@@ -51,7 +52,7 @@ type Indexer interface {
 
 	// ConnectBlock is invoked when the index manager is notified that a new
 	// block has been connected to the main chain.
-	ConnectBlock(dbTx database.Tx, block *types.SerializedBlock, stxos []blockchain.SpentTxOut) error
+	ConnectBlock(dbTx database.Tx, block *types.SerializedBlock, stxos []blockchain.SpentTxOut, ib meerdag.IBlock) error
 
 	// DisconnectBlock is invoked when the index manager is notified that a
 	// block has been disconnected from the main chain.

--- a/services/index/common.go
+++ b/services/index/common.go
@@ -10,9 +10,9 @@ package index
 import (
 	"encoding/binary"
 	"errors"
-	"github.com/Qitmeer/qng/core/blockchain"
 	"github.com/Qitmeer/qng-core/core/types"
 	"github.com/Qitmeer/qng-core/database"
+	"github.com/Qitmeer/qng/core/blockchain"
 )
 
 var (

--- a/services/index/existsaddrindex.go
+++ b/services/index/existsaddrindex.go
@@ -80,7 +80,7 @@ var _ Indexer = (*ExistsAddrIndex)(nil)
 // initialize for this index.
 //
 // This is part of the Indexer interface.
-func (idx *ExistsAddrIndex) Init() error {
+func (idx *ExistsAddrIndex) Init(chain *blockchain.BlockChain) error {
 	// Nothing to do.
 	return nil
 }

--- a/services/index/existsaddrindex.go
+++ b/services/index/existsaddrindex.go
@@ -6,6 +6,7 @@
 package index
 
 import (
+	"github.com/Qitmeer/qng-core/meerdag"
 	"sync"
 
 	"github.com/Qitmeer/qng-core/core/types"
@@ -201,7 +202,10 @@ func (idx *ExistsAddrIndex) ExistsAddresses(addrs []types.Address) ([]bool, erro
 // the transactions in the block involve.
 //
 // This is part of the Indexer interface.
-func (idx *ExistsAddrIndex) ConnectBlock(dbTx database.Tx, block *types.SerializedBlock, stxos []blockchain.SpentTxOut) error {
+func (idx *ExistsAddrIndex) ConnectBlock(dbTx database.Tx, block *types.SerializedBlock, stxos []blockchain.SpentTxOut, ib meerdag.IBlock) error {
+	if ib.GetStatus().KnownInvalid() {
+		return nil
+	}
 	var allTxns []*types.Tx
 	if block.Order() > 1 {
 		allTxns = block.Transactions()

--- a/services/index/existsaddrindex.go
+++ b/services/index/existsaddrindex.go
@@ -8,11 +8,11 @@ package index
 import (
 	"sync"
 
-	"github.com/Qitmeer/qng/core/blockchain"
 	"github.com/Qitmeer/qng-core/core/types"
 	"github.com/Qitmeer/qng-core/database"
 	"github.com/Qitmeer/qng-core/engine/txscript"
 	"github.com/Qitmeer/qng-core/params"
+	"github.com/Qitmeer/qng/core/blockchain"
 )
 
 var (

--- a/services/index/indexmgr.go
+++ b/services/index/indexmgr.go
@@ -81,25 +81,8 @@ func (m *Manager) Init(chain *blockchain.BlockChain, interrupt <-chan struct{}) 
 
 	// Initialize each of the enabled indexes.
 	for _, indexer := range m.enabledIndexes {
-		if err := indexer.Init(); err != nil {
+		if err := indexer.Init(chain); err != nil {
 			return err
-		}
-		if indexer.Name() == txIndexName {
-			indexer.(*TxIndex).chain = chain
-			if chain.CacheInvalidTx {
-				if indexer.(*TxIndex).curOrder == 0 {
-					m.db.Update(func(dbTx database.Tx) error {
-						dbTx.Metadata().Put(dbnamespace.CacheInvalidTxName, []byte{byte(0)})
-						return nil
-					})
-				}
-			} else {
-				m.db.Update(func(dbTx database.Tx) error {
-					dbTx.Metadata().Delete(dbnamespace.CacheInvalidTxName)
-					return nil
-				})
-			}
-
 		}
 	}
 

--- a/services/index/indexmgr.go
+++ b/services/index/indexmgr.go
@@ -7,12 +7,12 @@ import (
 	"fmt"
 	"github.com/Qitmeer/qng-core/common/hash"
 	"github.com/Qitmeer/qng-core/common/math"
-	"github.com/Qitmeer/qng/core/blockchain"
-	"github.com/Qitmeer/qng/core/dbnamespace"
 	"github.com/Qitmeer/qng-core/core/types"
 	"github.com/Qitmeer/qng-core/database"
 	"github.com/Qitmeer/qng-core/log"
 	"github.com/Qitmeer/qng-core/params"
+	"github.com/Qitmeer/qng/core/blockchain"
+	"github.com/Qitmeer/qng/core/dbnamespace"
 	"github.com/Qitmeer/qng/services/common/progresslog"
 )
 

--- a/services/index/indexmgr.go
+++ b/services/index/indexmgr.go
@@ -86,7 +86,7 @@ func (m *Manager) Init(chain *blockchain.BlockChain, interrupt <-chan struct{}) 
 		if indexer.Name() == txIndexName {
 			indexer.(*TxIndex).chain = chain
 			if chain.CacheInvalidTx {
-				if indexer.(*TxIndex).curBlockID == 0 {
+				if indexer.(*TxIndex).curOrder == 0 {
 					m.db.Update(func(dbTx database.Tx) error {
 						dbTx.Metadata().Put(dbnamespace.CacheInvalidTxName, []byte{byte(0)})
 						return nil
@@ -492,7 +492,7 @@ func (m *Manager) dbIndexDisconnectBlock(dbTx database.Tx, indexer Indexer, bloc
 		prevHash = &hash.ZeroHash
 		preOrder = math.MaxUint32
 	} else {
-		prevHash, err = dbFetchBlockHashByID(dbTx, order)
+		prevHash, err = dbFetchBlockHashByOrder(dbTx, order)
 		if err != nil {
 			return err
 		}

--- a/services/index/txindex.go
+++ b/services/index/txindex.go
@@ -9,10 +9,10 @@ import (
 	"errors"
 	"fmt"
 	"github.com/Qitmeer/qng-core/common/hash"
-	"github.com/Qitmeer/qng/core/blockchain"
 	"github.com/Qitmeer/qng-core/core/types"
 	"github.com/Qitmeer/qng-core/database"
 	"github.com/Qitmeer/qng-core/log"
+	"github.com/Qitmeer/qng/core/blockchain"
 )
 
 const (
@@ -347,7 +347,7 @@ func dbRemoveTxIdByHash(dbTx database.Tx, txhash hash.Hash) error {
 // TxIndex implements a transaction by hash index.  That is to say, it supports
 // querying all transactions by their hash.
 type TxIndex struct {
-	db         database.DB
+	db       database.DB
 	curOrder uint32
 
 	chain *blockchain.BlockChain

--- a/version/version.go
+++ b/version/version.go
@@ -27,7 +27,7 @@ const (
 const (
 	Major uint = 1
 	Minor uint = 0
-	Patch uint = 1
+	Patch uint = 2
 )
 
 var (


### PR DESCRIPTION
After QNG restart, `./qng --droptxindex` must be performed first.