### PR TITLE
fix web3 gasLimit

### DIFF
--- a/meerevm/chain/meerchain.go
+++ b/meerevm/chain/meerchain.go
@@ -312,7 +312,7 @@ func makeHeader(cfg *ethconfig.Config, parent *types.Block, state *state.StateDB
 		ParentHash: parent.Hash(),
 		Coinbase:   parent.Coinbase(),
 		Difficulty: common.Big1,
-		GasLimit:   0x7fffffffffffffff,
+		GasLimit:   0x8000000,
 		Number:     new(big.Int).Add(parent.Number(), common.Big1),
 		Time:       uint64(timestamp),
 	}


### PR DESCRIPTION
`Error : Number can only safely store up to 53 bits`

          webjs can handle max number is 2^53-1
          gasLimit 0x7fffffffffffffff is too bigger