### PR TITLE
make: the configurable dev build tag

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,9 @@ EXECUTABLE := qng
 GITVER := $(shell git rev-parse --short=7 HEAD )
 GITDIRTY := $(shell git diff --quiet || echo '-dirty')
 GITVERSION = "$(GITVER)$(GITDIRTY)"
-DEV=dev
+ifeq ($(DEV),)
+	DEV := dev
+endif
 RELEASE=release
 LDFLAG_DEV = -X github.com/Qitmeer/qng/version.Build=$(DEV)-$(GITVERSION)
 LDFLAG_RELEASE = -X github.com/Qitmeer/qng/version.Build=$(RELEASE)-$(GITVERSION)


### PR DESCRIPTION
Default make
```
$ make
Done building.
  QNG version 1.0.13+dev-0c26c43)
Run "./build/bin/qng" to launch.
```
Vs.  **```DEV={something else}```** when executing make
```
$ DEV=dev-docker make
Done building.
  QNG version 1.0.13+dev-docker-0c26c43)
Run "./build/bin/qng" to launch.
```