### PR TITLE
fix test failure

### DIFF
--- a/cmd/payledger/danode.go
+++ b/cmd/payledger/danode.go
@@ -263,7 +263,7 @@ func (node *DebugAddressNode) processAddress(blueM *map[uint]bool) error {
 }
 
 func isTxValid(db model.DataBase, txid *hash.Hash, txFullHash *hash.Hash, blockHash *hash.Hash) bool {
-	dtx, preBlockH, err := db.GetTxIndexEntry(txid, true)
+	dtx, preBlockH, err := db.GetTxIdxEntry(txid, true)
 	if err != nil {
 		return false
 	}

--- a/testutils/harness.go
+++ b/testutils/harness.go
@@ -149,11 +149,12 @@ func (h *Harness) connectWSNotifier() error {
 		OnRescanFinish:      h.Wallet.OnRescanFinish,
 	}
 	connCfg := &client.ConnConfig{
-		Host:       h.Node.config.rpclisten,
-		User:       h.Node.config.rpcuser,
-		Pass:       h.Node.config.rpcpass,
-		Endpoint:   "ws",
-		DisableTLS: false,
+		Host:                 h.Node.config.rpclisten,
+		User:                 h.Node.config.rpcuser,
+		Pass:                 h.Node.config.rpcpass,
+		Endpoint:             "ws",
+		DisableTLS:           false,
+		DisableAutoReconnect: true,
 	}
 	if !connCfg.DisableTLS {
 		certs, err := ioutil.ReadFile(h.Node.config.certFile)


### PR DESCRIPTION
1.  fix `cmd/payledger` compile error
2. set `DisableAutoReconnect` by default for ws-client in the test harness.