### PR TITLE
feat:support show meerevm bootnodes from DNS server

### DIFF
--- a/cmd/relaynode/README.md
+++ b/cmd/relaynode/README.md
@@ -56,3 +56,9 @@ If you don't want to use the default configuration, you can:
 * If your environment is having trouble getting public IP, please try using `./relaynode --externalip=[Your Public IP]`
 
 * If you want to use DNS service: `./relaynode --externalip=[Your domain name]`
+
+
+* Show network meerevm bootnodes from DNS server 
+```bash
+~ ./relaynode --network=testnet meerdnsnodes
+```

--- a/cmd/relaynode/crawl/cmd.go
+++ b/cmd/relaynode/crawl/cmd.go
@@ -28,7 +28,7 @@ var (
 )
 
 func Cmds() []*cli.Command {
-	return []*cli.Command{amanaCmd(), amanaNodesCmd(), meerCmd(), meerNodesCmd(), bootNodesCmd()}
+	return []*cli.Command{amanaCmd(), amanaNodesCmd(), meerCmd(), meerNodesCmd(), meerDNSNodesCmd(), bootNodesCmd()}
 }
 
 // commandHasFlag returns true if the current command supports the given flag.


### PR DESCRIPTION
For example: `./relaynode --network=testnet meerdnsnodes`