### PR TITLE
Potential fix for code scanning alert no. 11: Incorrect conversion between integer types

### DIFF
--- a/core/blockchain/blockindex.go
+++ b/core/blockchain/blockindex.go
@@ -3,6 +3,7 @@ package blockchain
 
 import (
 	"fmt"
+	"math"
 	"github.com/Qitmeer/qng/common/hash"
 	"github.com/Qitmeer/qng/consensus/engine/pow"
 	"github.com/Qitmeer/qng/consensus/forks"
@@ -57,6 +58,10 @@ func (b *BlockChain) GetDAGBlock(h *hash.Hash) meerdag.IBlock {
 }
 
 func (b *BlockChain) GetBlockByOrder(order uint64) model.Block {
+	if order > math.MaxUint {
+		log.Error(fmt.Sprintf("Order value %d exceeds maximum uint value %d", order, math.MaxUint))
+		return nil
+	}
 	return b.bd.GetBlockByOrder(uint(order))
 }
 


### PR DESCRIPTION
Potential fix for [https://github.com/Qitmeer/qng/security/code-scanning/11](https://github.com/Qitmeer/qng/security/code-scanning/11)

To fix the issue, we need to ensure that the conversion from `uint64` to `uint` is safe. This can be achieved by adding an upper bound check before performing the conversion. Specifically:
1. Use the `math.MaxUint` constant to check if the `uint64` value exceeds the maximum value of `uint`.
2. If the value is out of bounds, handle the error appropriately (e.g., return `nil` or log an error message).
3. Ensure the fix does not alter the existing functionality of the `GetBlockByOrder` method.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
