### PR TITLE
Potential fix for code scanning alert no. 6: Size computation for allocation may overflow

### DIFF
--- a/log/logger.go
+++ b/log/logger.go
@@ -153,12 +153,11 @@ func (l *logger) New(ctx ...interface{}) Logger {
 func newContext(prefix []interface{}, suffix []interface{}) []interface{} {
 	normalizedSuffix := normalize(suffix)
 	maxSize := 64 * 1024 * 1024 // Maximum allowed size for the context
-	totalSize := len(prefix) + len(normalizedSuffix)
-	if totalSize > maxSize {
-		fmt.Fprintf(os.Stderr, "Context size exceeds maximum allowed size: %d > %d\n", totalSize, maxSize)
+	if len(prefix) > maxSize || len(normalizedSuffix) > maxSize || len(prefix)+len(normalizedSuffix) > maxSize {
+		fmt.Fprintf(os.Stderr, "Context size exceeds maximum allowed size or causes overflow: prefix=%d, suffix=%d, max=%d\n", len(prefix), len(normalizedSuffix), maxSize)
 		normalizedSuffix = normalizedSuffix[:maxSize-len(prefix)]
-		totalSize = maxSize
 	}
+	totalSize := len(prefix) + len(normalizedSuffix)
 	newCtx := make([]interface{}, totalSize)
 	n := copy(newCtx, prefix)
 	copy(newCtx[n:], normalizedSuffix)

--- a/log/logger.go
+++ b/log/logger.go
@@ -152,7 +152,14 @@ func (l *logger) New(ctx ...interface{}) Logger {
 
 func newContext(prefix []interface{}, suffix []interface{}) []interface{} {
 	normalizedSuffix := normalize(suffix)
-	newCtx := make([]interface{}, len(prefix)+len(normalizedSuffix))
+	maxSize := 64 * 1024 * 1024 // Maximum allowed size for the context
+	totalSize := len(prefix) + len(normalizedSuffix)
+	if totalSize > maxSize {
+		fmt.Fprintf(os.Stderr, "Context size exceeds maximum allowed size: %d > %d\n", totalSize, maxSize)
+		normalizedSuffix = normalizedSuffix[:maxSize-len(prefix)]
+		totalSize = maxSize
+	}
+	newCtx := make([]interface{}, totalSize)
 	n := copy(newCtx, prefix)
 	copy(newCtx[n:], normalizedSuffix)
 	return newCtx


### PR DESCRIPTION
Potential fix for [https://github.com/Qitmeer/qng/security/code-scanning/6](https://github.com/Qitmeer/qng/security/code-scanning/6)

To fix the issue, we need to validate the size of the `normalizedSuffix` slice before performing the allocation in `newContext`. Specifically:
1. Add a size check in `newContext` to ensure that the combined size of `prefix` and `normalizedSuffix` does not exceed a safe limit (e.g., 64 MB).
2. If the size exceeds the limit, log an error or truncate the input to prevent overflow.
3. Ensure that the `normalize` function does not introduce additional risks by validating its input size.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
