### PR TITLE
Potential fix for code scanning alert no. 7: Size computation for allocation may overflow

### DIFF
--- a/log/logger.go
+++ b/log/logger.go
@@ -3,6 +3,7 @@ package log
 import (
 	"fmt"
 	"github.com/Qitmeer/qng/common/roughtime"
+	"math"
 	"os"
 	"time"
 
@@ -230,6 +231,9 @@ type Lazy struct {
 type Ctx map[string]interface{}
 
 func (c Ctx) toArray() []interface{} {
+	if len(c) > (math.MaxInt / 2) {
+		panic("Ctx size too large, potential overflow in allocation")
+	}
 	arr := make([]interface{}, len(c)*2)
 
 	i := 0


### PR DESCRIPTION
Potential fix for [https://github.com/Qitmeer/qng/security/code-scanning/7](https://github.com/Qitmeer/qng/security/code-scanning/7)

To fix the issue, we need to ensure that the computation of `len(c)*2` does not overflow. This can be achieved by validating the size of `c` before performing the allocation. Specifically:
1. Add a check to ensure that `len(c)` is within a safe range (e.g., less than `math.MaxInt/2`).
2. If the size exceeds the safe range, return an error or handle the situation gracefully.

The fix will involve modifying the `toArray` method in `log/logger.go` to include a size validation step.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
