### PR TITLE
main: show detail MeerEVM version when using '-V' flag

### DIFF
--- a/services/common/load.go
+++ b/services/common/load.go
@@ -10,6 +10,7 @@ import (
 	"os"
 	"path/filepath"
 	"runtime"
+	"runtime/debug"
 	"strconv"
 	"strings"
 
@@ -43,7 +44,21 @@ func LoadConfig(ctx *cli.Context, parsefile bool) (*config.Config, error) {
 	appName := filepath.Base(os.Args[0])
 	appName = strings.TrimSuffix(appName, filepath.Ext(appName))
 	if cfg.ShowVersion {
-		fmt.Printf("%s version %s (Go version %s)\n", appName, version.String(), runtime.Version())
+		info, ok := debug.ReadBuildInfo()
+		if !ok {
+			panic("no build info")
+		}
+		eVersion := "unknown"
+		for _, dep := range info.Deps {
+			if dep.Path == "github.com/ethereum/go-ethereum" {
+				eVersion = fmt.Sprintf("%v", dep.Version)
+				if dep.Replace != nil {
+					eVersion = fmt.Sprintf("%v", dep.Replace.Version)
+				}
+				break
+			}
+		}
+		fmt.Printf("%s version %s (MeerEVM %s) (Go version %s)\n", appName, version.String(), eVersion, runtime.Version())
 		os.Exit(0)
 	}
 


### PR DESCRIPTION
```bash
./build/bin/qng -V
qng version 2.3.0+dev-ad03e04 (MeerEVM v1.16.9-q.0) (Go version go1.26.1)
```